### PR TITLE
Fix symbol placement issues

### DIFF
--- a/cardStyling.css
+++ b/cardStyling.css
@@ -277,7 +277,7 @@
         .card .iconRace {
             top: 160px;
         }
-        .card.pony.G:not(.R) .iconRace {
+        .card.pony.G:not(.R) .iconRace, .card.start.G:not(.R) .iconRace {
             top:86px;
         }
         /*Regular*/
@@ -310,7 +310,7 @@
         .card .iconGender {
             top: 56px;
         }
-        .card.pony.R:not(.G) .iconGender {
+        .card.pony.R:not(.G) .iconGender, .card.start.R:not(.G) .iconGender {
             top:86px;
         }
         .card.pony.female .iconGender, .card.start.female .iconGender, button[value=female] {

--- a/cardStyling.css
+++ b/cardStyling.css
@@ -274,7 +274,7 @@
             color: #edefee;
         }
     /*Race Icon*/
-        .card.pony .iconRace {
+        .card .iconRace {
             top: 160px;
         }
         .card.pony.G:not(.R) .iconRace {


### PR DESCRIPTION
This pull request fixes two issues:
1. When changing the card type to start card, the race icon jumps to the top of the card.  This is because the CSS style for raceIcon is currently set to .card.pony .raceIcon, rather than just .card .raceIcon (like it is for genderIcon).
2. The styles that govern how race/gender icons look when there's only one or the other only apply to pony-class cards, not to start-class cards.
